### PR TITLE
Fix wrong quote format

### DIFF
--- a/src/navigator/mainNavigator.js
+++ b/src/navigator/mainNavigator.js
@@ -29,7 +29,7 @@ const DrawerAppNavigator = createDrawerNavigator(
   },
   {
     contentComponent: SideMenu,
-    initialRouteName: “CbSplashScreen2193302”, // Splash Screen
+    initialRouteName: "CbSplashScreen2193302", // Splash Screen
   },
 );
 


### PR DESCRIPTION
This PR fixes a syntax error on the navigator setup:
> error: SyntaxError: /home/daniel/code/crowdbotics-apps@my-new-mobile-app23832/src/navigator/mainNavigator.js: Unexpected character '“' (32:22)

The character at question was a different unexpected unicode quotation mark that failed to build.